### PR TITLE
Make jWallet available under /jwallet path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:8-onbuild AS build
 
 ENV MAIN_RPC_ADDR=main.node.jwallet.network \
-    ROPSTEN_RPC_ADDR=ropsten.node.jwallet.network
+    ROPSTEN_RPC_ADDR=ropsten.node.jwallet.network \
+    PUBLIC_URL=/jwallet
 
 RUN npm run compile:prod
 


### PR DESCRIPTION
For now `master` branch should be available under `/jwallet` route path. This PR should fix it.