### PR TITLE
Add ability to disable ETH for dev env

### DIFF
--- a/src/components/AssetItem/AssetItem.js
+++ b/src/components/AssetItem/AssetItem.js
@@ -168,7 +168,7 @@ class AssetItem extends PureComponent<Props, StateProps> {
                 <JSwitch
                   onChange={setIsActive}
                   isChecked={isActive}
-                  isDisabled={isActive && checkETH(address)}
+                  isDisabled={!__DEV__ && checkETH(address) && isActive}
                   name={address}
                 />
               </div>


### PR DESCRIPTION
We fetch `ETH` txs from `ropsten` for `DEV` env (because of `api.etherscan` CORS header issue). But at the same time we manage blocks for `main` network, this is cause failing of majority requests to `ropsten.etherscan`. So we need to left ability to disable ETH asset.