### PR TITLE
JWWEB-188: Update redux-persist management

### DIFF
--- a/src/store/persistReducers.js
+++ b/src/store/persistReducers.js
@@ -1,0 +1,60 @@
+// @flow
+
+import storage from 'localforage'
+import { persistReducer } from 'redux-persist'
+
+import type { Reducer } from 'redux'
+import type { AppAction } from 'routes'
+import type { PersistConfig } from 'redux-persist/lib/types.js.flow'
+
+type PersistableReducerName =
+  'blocks' |
+  'wallets' |
+  'balances' |
+  'comments' |
+  'networks' |
+  'favorites' |
+  'transactions' |
+  'digitalAssets' |
+  'walletsAddresses'
+
+type PersistableReducer = Reducer<any, AppAction>
+type PersistableReducers = { [PersistableReducerName]: ?PersistableReducer }
+
+function persistConfig(reducerName: PersistableReducerName): PersistConfig {
+  return {
+    storage,
+    whitelist: ['persist'],
+    key: `jwallet-web-${reducerName}`,
+  }
+}
+
+function getPersistableReducer(
+  name: PersistableReducerName,
+  reducer: ?PersistableReducer,
+): ?PersistableReducer {
+  return reducer && persistReducer/* :: < any, AppAction > */(persistConfig(name), reducer)
+}
+
+function persistReducers(reducers: PersistableReducers) {
+  const persistableReducers: PersistableReducers = Object.keys(reducers).reduce((
+    result: PersistableReducers,
+    reducerName: PersistableReducerName,
+  ): PersistableReducers => {
+    const persistableReducer: ?PersistableReducer
+      = getPersistableReducer(reducerName, reducers[reducerName])
+
+    if (!persistableReducer) {
+      return result
+    }
+
+    return {
+      ...result,
+      [reducerName]: persistableReducer,
+    }
+  }, {})
+
+  return persistableReducers
+}
+
+export default persistReducers

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -1,11 +1,9 @@
 // @flow
 
-import storage from 'localforage'
 import { combineReducers, type Reducer } from 'redux'
-import { persistReducer } from 'redux-persist'
 import { routerReducer as router } from 'react-router-redux'
 
-import { type AppAction } from 'routes'
+import type { AppAction } from 'routes'
 
 // wallets
 import wallets from 'routes/Wallets/modules/wallets'
@@ -15,15 +13,13 @@ import walletsBackup from 'routes/Wallets/routes/Backup/modules/walletsBackup'
 import walletsAddresses from 'routes/Wallets/routes/Addresses/modules/walletsAddresses'
 import walletsRenameAddress from 'routes/Wallets/routes/RenameAddress/modules/walletsRenameAddress'
 
-// Digital ssets
+// digital assets
 import digitalAssets from 'routes/DigitalAssets/modules/digitalAssets'
-import addAsset from 'routes/DigitalAssets/routes/AddAsset/modules/addAsset'
-import editAsset from 'routes/DigitalAssets/routes/EditAsset/modules/editAsset'
+import digitalAssetsAdd from 'routes/DigitalAssets/routes/AddAsset/modules/addAsset'
+import digitalAssetsEdit from 'routes/DigitalAssets/routes/EditAsset/modules/editAsset'
+import digitalAssetsSend from 'routes/DigitalAssets/routes/Send/modules/digitalAssetsSend'
 import digitalAssetsGrid from 'routes/DigitalAssets/routes/Grid/modules/digitalAssetsGrid'
 import digitalAssetsManage from 'routes/DigitalAssets/routes/Manage/modules/digitalAssetsManage'
-
-// Send digital asset
-import digitalAssetsSend from 'routes/DigitalAssets/routes/Send/modules/digitalAssetsSend'
 
 // networks
 import networks from 'routes/modules/networks'
@@ -46,55 +42,38 @@ import settings from 'routes/Settings/modules/settings'
 // favorites
 import favorites from 'routes/Favorites/modules/favorites'
 
-const persistConfig = {
-  storage,
-  key: 'jwallet-web',
-  whitelist: [
-    'blocks',
-    'wallets',
-    'balances',
-    'comments',
-    'favorites',
-    'transactions',
-    'digitalAssets',
-    'walletsAddresses',
-  ],
-}
+import persistReducers from './persistReducers'
 
 export function makeRootReducer() {
   const rootReducer: Reducer<AppState, AppAction> = combineReducers({
     // wallets
-    wallets,
     walletsCreate,
     walletsImport,
     walletsBackup,
-    walletsAddresses,
     walletsRenameAddress,
-    // networks
-    networks,
     // digitalAssets
-    digitalAssets,
+    digitalAssetsAdd,
+    digitalAssetsEdit,
+    digitalAssetsSend,
     digitalAssetsGrid,
     digitalAssetsManage,
-    addAsset,
-    editAsset,
-    // send asset
-    digitalAssetsSend,
-    // blocks
-    blocks,
-    // balances
-    balances,
-    // comments
-    comments,
-    // transactions
-    transactions,
     // settings
     settings,
-    // favorites
-    favorites,
     // router
     router,
+    // persist
+    ...persistReducers({
+      blocks,
+      wallets,
+      balances,
+      comments,
+      networks,
+      favorites,
+      transactions,
+      digitalAssets,
+      walletsAddresses,
+    }),
   })
 
-  return persistReducer/* :: < AppState, AppAction > */(persistConfig, rootReducer)
+  return rootReducer
 }


### PR DESCRIPTION
All persistable reducers are storing by specific key in IndexedDB (separate DB store).
Also, only `persist` container from reducer root is storing.

Basically, we create same config for each reducer to persist:
```
  {
    storage,
    whitelist: ['persist'],
    key: `jwallet-web-${reducerName}`,
  }
```

And then we pass them to `combineReducers` with `persistReducer` wrapper:
```
persistReducer(persistConfig(name), reducer)
```