### PR TITLE
Fix assets management toggle

### DIFF
--- a/src/data/assets/index.js
+++ b/src/data/assets/index.js
@@ -1,11 +1,28 @@
 // @flow
 
+import { getAddressChecksum } from 'utils/address'
+
 import ethereum from './ethereum'
-import mainnet from '../../../assets/mainnet/assets.json'
-import ropsten from '../../../assets/ropsten/assets.json'
+import rawMainnet from '../../../assets/mainnet/assets.json'
+import rawRopsten from '../../../assets/ropsten/assets.json'
+
+// FIXME: this should be added one-time during build of the assets list
+const addChecksum = (asset) => {
+  if (asset.blockchainParams && asset.blockchainParams.address) {
+    return {
+      ...asset,
+      blockchainParams: {
+        ...asset.blockchainParams,
+        address: getAddressChecksum(asset.blockchainParams.address),
+      },
+    }
+  }
+
+  return asset
+}
 
 export default {
-  mainnet,
-  ropsten,
+  mainnet: rawMainnet.map(asset => addChecksum(asset)),
+  ropsten: rawRopsten.map(asset => addChecksum(asset)),
   ethereum,
 }


### PR DESCRIPTION
After yesterday checksum fixes assets started to rely on checksumed indices, but data still holds addresses without checksum. We fix it in run-time, but it's not a good solution – in the future we need to update assets database.

Also important: you need to clean your indexedDB for this to work.