### PR TITLE
JWWEB-561: Fix assets management toggle

### DIFF
--- a/src/routes/DigitalAssets/sagas/digitalAssets.js
+++ b/src/routes/DigitalAssets/sagas/digitalAssets.js
@@ -47,6 +47,10 @@ function mergeItems(items: DigitalAssets): DigitalAssets {
       [addressWithChecksum]: {
         ...item,
         isActive: false,
+        blockchainParams: {
+          ...item.blockchainParams,
+          address: addressWithChecksum,
+        },
       },
     }
   }, {})


### PR DESCRIPTION
After yesterday checksum fixes assets started to rely on checksumed indices, but data still holds addresses without checksum. We fix it in run-time, but it's not a good solution – in the future we need to update assets database.

Also important: you need to clean your indexedDB for this to work.