### PR TITLE
Fix flowtype imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,6 +143,6 @@
     "flowtype/semi": [2, "never"],
     "flowtype/space-before-generic-bracket": [2, "never"],
     "flowtype/type-id-match": [2, "^([A-Z][a-z0-9]*)+$"],
-    "flowtype/type-import-style": [2, "declaration"]
+    "flowtype/type-import-style": [2, "identifier"]
   }
 }

--- a/flow-typed/redux/appState.js
+++ b/flow-typed/redux/appState.js
@@ -1,8 +1,9 @@
 // @flow
 
-/* eslint-disable-next-line no-unused-vars */
 import {
+  // eslint-disable-next-line no-unused-vars
   type Saga,
+  // eslint-disable-next-line no-unused-vars
   type Channel,
 } from 'redux-saga'
 

--- a/flow-typed/redux/appState.js
+++ b/flow-typed/redux/appState.js
@@ -1,7 +1,10 @@
 // @flow
 
 /* eslint-disable-next-line no-unused-vars */
-import type { Saga, Channel } from 'redux-saga'
+import {
+  type Saga,
+  type Channel,
+} from 'redux-saga'
 
 declare type AppState = {
   // wallets

--- a/flow-typed/types.js
+++ b/flow-typed/types.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { ComponentType } from 'react'
+import { type ComponentType } from 'react'
 
 declare type Index = number
 
@@ -46,13 +46,13 @@ declare type ReactRouterState = {
     +pathname: string,
     +hash: string,
     +key: string,
-    +search: string
+    +search: string,
   },
   +routes: [{
-    +path: string
+    +path: string,
   }],
   params: {
-    [string]: string
+    [string]: string,
   },
-  components: [ComponentType]
+  components: [ComponentType],
 }

--- a/flow-typed/types.js
+++ b/flow-typed/types.js
@@ -10,11 +10,16 @@ declare type BalanceString = string
 declare type Address = string
 declare type OwnerAddress = Address
 declare type EthereumAddress = 'Ethereum'
+
+// eslint-disable-next-line flowtype/require-compound-type-alias
 declare type AssetAddress = Address | EthereumAddress
 
 declare type AddressNames = { [Address]: ?string }
 
+// eslint-disable-next-line flowtype/require-compound-type-alias
 declare type SortDirection = 'asc' | 'desc'
+
+// eslint-disable-next-line flowtype/require-compound-type-alias
 declare type LanguageCode = 'en' | 'ko' | 'zh' | 'ja'
 
 declare type FormFields = { [string]: ?string }

--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -5,14 +5,14 @@ import { Router } from 'react-router'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
 
-import type { Persistor } from 'redux-persist/lib/types'
+import { type Persistor } from 'redux-persist/lib/types'
 
-import type {
-  Store,
-  Dispatch,
+import {
+  type Store,
+  type Dispatch,
 } from 'redux'
 
-import type { AppAction } from 'routes'
+import { type AppAction } from 'routes'
 
 import startSessionWatcher from 'utils/browser/startSessionWatcher'
 import SingularTabBlockScreen from 'components/SingularTabBlockScreen/SingularTabBlockScreen'

--- a/src/components/AssetBalance/AssetBalance.js
+++ b/src/components/AssetBalance/AssetBalance.js
@@ -4,9 +4,9 @@ import React, { PureComponent } from 'react'
 
 import JText from 'components/base/JText'
 
-import type {
-  JTextSize,
-  JTextColor,
+import {
+  type JTextSize,
+  type JTextColor,
 } from 'components/base/JText/JText'
 
 type Props = {|

--- a/src/components/ButtonWithConfirm/ButtonWithConfirm.js
+++ b/src/components/ButtonWithConfirm/ButtonWithConfirm.js
@@ -15,8 +15,8 @@ import {
   JFlatButton,
 } from 'components/base'
 
-import type { JIconColor } from 'components/base/JIcon/JIcon'
-import type { JFlatButtonColor } from 'components/base/JFlatButton/JFlatButton'
+import { type JIconColor } from 'components/base/JIcon/JIcon'
+import { type JFlatButtonColor } from 'components/base/JFlatButton/JFlatButton'
 
 type Props = {|
   +onClick: (SyntheticEvent<HTMLDivElement>) => void,

--- a/src/components/OverlayNotification/OverlayNotification.js
+++ b/src/components/OverlayNotification/OverlayNotification.js
@@ -5,10 +5,10 @@ import React, { PureComponent } from 'react'
 
 import JThumbnail from 'components/base/JThumbnail'
 
-import type {
-  JThumbnailColor,
-  JThumbnailImage,
-  JThumbnailDescription,
+import {
+  type JThumbnailColor,
+  type JThumbnailImage,
+  type JThumbnailDescription,
 } from 'components/base/JThumbnail/JThumbnail'
 
 type Props = {|

--- a/src/components/PasswordField/PasswordField.js
+++ b/src/components/PasswordField/PasswordField.js
@@ -7,7 +7,7 @@ import config from 'config'
 import JInput from 'components/base/JInput'
 import checkPasswordStrength from 'utils/encryption/checkPasswordStrength'
 
-import type { JInputColor } from 'components/base/JInput/JInput'
+import { type JInputColor } from 'components/base/JInput/JInput'
 
 import Indicator from './Indicator'
 

--- a/src/components/SettingsGrid/SettingsGridCard/SettingsGridCard.js
+++ b/src/components/SettingsGrid/SettingsGridCard/SettingsGridCard.js
@@ -12,7 +12,7 @@ import {
   JText,
 } from 'components/base'
 
-import type { JIconColor } from 'components/base/JIcon/JIcon'
+import { type JIconColor } from 'components/base/JIcon/JIcon'
 
 export type Props = {|
   +title: string,

--- a/src/components/SettingsGrid/SettingsGridCard/index.js
+++ b/src/components/SettingsGrid/SettingsGridCard/index.js
@@ -1,8 +1,8 @@
 // @flow
 
-import SettingsGridCard from './SettingsGridCard'
-
-import type {  Props } from './SettingsGridCard'
+import SettingsGridCard, {
+  type Props,
+} from './SettingsGridCard'
 
 export type SettingsGridCardProps = Props
 

--- a/src/components/base/JFlatButton/JFlatButton.js
+++ b/src/components/base/JFlatButton/JFlatButton.js
@@ -17,9 +17,9 @@ import {
   JLoader,
 } from 'components/base'
 
-import type {
-  JIconSize,
-  JIconColor,
+import {
+  type JIconSize,
+  type JIconColor,
 } from 'components/base/JIcon/JIcon'
 
 export type JFlatButtonColor = 'blue' | 'gray' | 'sky' | 'white'

--- a/src/components/base/JInput/JInputField.js
+++ b/src/components/base/JInput/JInputField.js
@@ -2,11 +2,9 @@
 
 import React from 'react'
 
-import JInput from './JInput'
-
-import type {
-  JInputType,
-  JInputColor,
+import JInput, {
+  type JInputType,
+  type JInputColor,
 } from './JInput'
 
 type InputValidateType = 'touched' | 'visited'

--- a/src/components/base/JRaisedButton/JRaisedButton.js
+++ b/src/components/base/JRaisedButton/JRaisedButton.js
@@ -11,12 +11,12 @@ import {
   JLoader,
 } from 'components/base'
 
-import type { JTextColor } from 'components/base/JText/JText'
-import type { JLoaderColor } from 'components/base/JLoader/JLoader'
+import { type JTextColor } from 'components/base/JText/JText'
+import { type JLoaderColor } from 'components/base/JLoader/JLoader'
 
-import type {
-  JIconSize,
-  JIconColor,
+import {
+  type JIconSize,
+  type JIconColor,
 } from 'components/base/JIcon/JIcon'
 
 type JRaisedButtonColor = 'blue' | 'white'

--- a/src/routes/Settings/SettingsIndexView.js
+++ b/src/routes/Settings/SettingsIndexView.js
@@ -7,14 +7,15 @@ import { Scrollbars } from 'react-custom-scrollbars'
 import SettingsGrid from 'components/SettingsGrid'
 import escapeRegExp from 'utils/regexp/escapeRegExp'
 import formatCurrency from 'utils/formatters/formatCurrency'
-import SettingsGridCard from 'components/SettingsGrid/SettingsGridCard'
 
 import {
   JText,
   JSearch,
 } from 'components/base'
 
-import type { SettingsGridCardProps } from 'components/SettingsGrid/SettingsGridCard'
+import SettingsGridCard, {
+  type SettingsGridCardProps,
+} from 'components/SettingsGrid/SettingsGridCard'
 
 type Props = {|
   ...SettingsState,

--- a/src/routes/Settings/routes/Currency/CurrencyContainer.js
+++ b/src/routes/Settings/routes/Currency/CurrencyContainer.js
@@ -10,9 +10,9 @@ import { setFiatCurrency } from 'store/modules/settings'
 
 import CurrencyView from './CurrencyView'
 
-import type {
-  CurrencyFormFieldErrors,
-  CurrencyFormFieldValues,
+import {
+  type CurrencyFormFieldErrors,
+  type CurrencyFormFieldValues,
 } from './types'
 
 const validate = ({ fiatCurrency }: CurrencyFormFieldValues): CurrencyFormFieldErrors => {

--- a/src/routes/Settings/routes/Currency/CurrencyView.js
+++ b/src/routes/Settings/routes/Currency/CurrencyView.js
@@ -15,9 +15,9 @@ import { CurrencyPickerField } from './components/CurrencyPickerField'
 
 import './currencyView.scss'
 
-import type {
-  CurrencyFormFieldValues,
-  CurrencyFormFieldErrors,
+import {
+  type CurrencyFormFieldValues,
+  type CurrencyFormFieldErrors,
 } from './types'
 
 type Props = {|

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,9 +7,9 @@ import {
   reactRouterOnEnterPageView,
 } from 'utils/analytics'
 
-import type { CoreAction } from 'store/modules/core'
-import type { NotFoundAction } from 'store/modules/notFound'
-import type { DigitalAssetsModuleAction } from 'store/modules/digitalAssets'
+import { type CoreAction } from 'store/modules/core'
+import { type NotFoundAction } from 'store/modules/notFound'
+import { type DigitalAssetsModuleAction } from 'store/modules/digitalAssets'
 
 import Wallets from './Wallets'
 import Settings from './Settings'

--- a/src/store/modules/digitalAssets.js
+++ b/src/store/modules/digitalAssets.js
@@ -1,8 +1,8 @@
 // @flow
 
-import type { DigitalAssetsGridAction } from 'store/modules/digitalAssetsGrid'
-import type { AddAssetAction } from 'store/modules/addAsset'
-import type { EditAssetAction } from 'store/modules/editAsset'
+import { type DigitalAssetsGridAction } from 'store/modules/digitalAssetsGrid'
+import { type AddAssetAction } from 'store/modules/addAsset'
+import { type EditAssetAction } from 'store/modules/editAsset'
 
 export const INIT = '@@digitalAssets/INIT'
 

--- a/src/store/modules/index.js
+++ b/src/store/modules/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { CoreAction as Action } from './core'
+import { type CoreAction as Action } from './core'
 
 export type CoreAction = Action
 

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { CurrencyFormFieldValues } from 'routes/Settings/routes/Currency/types'
+import { type CurrencyFormFieldValues } from 'routes/Settings/routes/Currency/types'
 
 export const CHANGE_PAYMENT_PASSWORD = '@@settings/CHANGE_PAYMENT_PASSWORD'
 export const VALIDATION_PASSWORD_FORM = '@@settings/VALIDATION_PASSWORD_FORM'

--- a/src/store/modules/walletsCreate.js
+++ b/src/store/modules/walletsCreate.js
@@ -1,8 +1,8 @@
 // @flow
 
-import type {
-  WalletsCreateRequestPayload,
-  WalletsSetWalletsActionPayload,
+import {
+  type WalletsCreateRequestPayload,
+  type WalletsSetWalletsActionPayload,
 } from 'store/modules/wallets'
 
 export const OPEN_VIEW = '@@walletsCreate/OPEN_VIEW'

--- a/src/store/modules/walletsImport.js
+++ b/src/store/modules/walletsImport.js
@@ -1,8 +1,8 @@
 // @flow
 
-import type {
-  WalletsImportRequestPayload,
-  WalletsSetWalletsActionPayload,
+import {
+  type WalletsImportRequestPayload,
+  type WalletsSetWalletsActionPayload,
 } from 'store/modules/wallets'
 
 export const OPEN_VIEW = '@@walletsImport/OPEN_VIEW'

--- a/src/store/persistReducers.js
+++ b/src/store/persistReducers.js
@@ -3,9 +3,9 @@
 import storage from 'localforage'
 import { persistReducer } from 'redux-persist'
 
-import type { Reducer } from 'redux'
-import type { AppAction } from 'routes'
-import type { PersistConfig } from 'redux-persist/lib/types.js.flow'
+import { type Reducer } from 'redux'
+import { type AppAction } from 'routes'
+import { type PersistConfig } from 'redux-persist/lib/types.js.flow'
 
 type PersistableReducerName =
   'blocks' |

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -1,9 +1,11 @@
 // @flow
 
-import { combineReducers } from 'redux'
-import { routerReducer as router } from 'react-router-redux'
+import {
+  combineReducers,
+  type Reducer,
+} from 'redux'
 
-import type { Reducer } from 'redux'
+import { routerReducer as router } from 'react-router-redux'
 
 import blocks from 'store/modules/blocks'
 import ticker from 'store/modules/ticker'
@@ -31,7 +33,7 @@ import walletsBackup from 'store/modules/walletsBackup'
 import walletsAddresses from 'store/modules/walletsAddresses'
 import walletsRenameAddress from 'store/modules/walletsRenameAddress'
 
-import type { AppAction } from 'routes'
+import { type AppAction } from 'routes'
 
 import persistReducers from './persistReducers'
 

--- a/src/store/sagas/balances.js
+++ b/src/store/sagas/balances.js
@@ -2,7 +2,11 @@
 
 import { isEmpty } from 'lodash-es'
 
-import { delay } from 'redux-saga'
+import {
+  delay,
+  type Task,
+} from 'redux-saga'
+
 import { t } from 'ttag'
 
 import {
@@ -15,8 +19,6 @@ import {
   select,
   takeEvery,
 } from 'redux-saga/effects'
-
-import type { Task } from 'redux-saga'
 
 import config from 'config'
 import web3 from 'services/web3'

--- a/src/store/sagas/blocks.js
+++ b/src/store/sagas/blocks.js
@@ -6,6 +6,7 @@ import {
   delay,
   channel,
   buffers,
+  type Task,
 } from 'redux-saga'
 
 import {
@@ -19,8 +20,6 @@ import {
   cancelled,
   takeEvery,
 } from 'redux-saga/effects'
-
-import type { Task } from 'redux-saga'
 
 import config from 'config'
 import web3 from 'services/web3'

--- a/src/store/sagas/ticker.js
+++ b/src/store/sagas/ticker.js
@@ -1,6 +1,9 @@
 // @flow
 
-import { delay } from 'redux-saga'
+import {
+  delay,
+  type Task,
+} from 'redux-saga'
 
 import {
   put,
@@ -11,8 +14,6 @@ import {
   select,
   takeEvery,
 } from 'redux-saga/effects'
-
-import type { Task } from 'redux-saga'
 
 import config from 'config'
 import tickerService from 'services/ticker'

--- a/src/store/sagas/transactions.js
+++ b/src/store/sagas/transactions.js
@@ -1,7 +1,10 @@
 // @flow
 
 import { t } from 'ttag'
-import { delay } from 'redux-saga'
+import {
+  delay,
+  type Task,
+} from 'redux-saga'
 
 import {
   all,
@@ -13,8 +16,6 @@ import {
   select,
   takeEvery,
 } from 'redux-saga/effects'
-
-import type { Task } from 'redux-saga'
 
 import config from 'config'
 import { selectProcessingBlock } from 'store/selectors/blocks'

--- a/src/utils/browser/reactRouterBack.js
+++ b/src/utils/browser/reactRouterBack.js
@@ -3,9 +3,8 @@
 import {
   push,
   goBack,
+  type RouterAction,
 } from 'react-router-redux'
-
-import type { RouterAction } from 'react-router-redux'
 
 type RouterBackPayload = {|
   +fallbackUrl?: string,

--- a/src/utils/browser/startSessionWatcher.js
+++ b/src/utils/browser/startSessionWatcher.js
@@ -2,7 +2,7 @@
 
 import uuidv4 from 'uuid/v4'
 import config from 'config'
-import type { Persistor } from 'redux-persist/lib/types'
+import { type Persistor } from 'redux-persist/lib/types'
 import { closeMenuLayout } from 'store/modules/core'
 
 export default function startSessionWatcher(

--- a/src/utils/formatters/formatAssetBalance.js
+++ b/src/utils/formatters/formatAssetBalance.js
@@ -7,7 +7,7 @@ import {
   formatBalance,
 } from 'utils/numbers'
 
-import type { ToBigNumberValue } from 'utils/numbers/toBigNumber'
+import { type ToBigNumberValue } from 'utils/numbers/toBigNumber'
 
 export default function formatAssetBalance(
   asset: AssetAddress,

--- a/src/utils/numbers/divDecimals.js
+++ b/src/utils/numbers/divDecimals.js
@@ -1,8 +1,8 @@
 // @flow
 
-import toBigNumber from './toBigNumber'
-
-import type { ToBigNumberValue } from './toBigNumber'
+import toBigNumber, {
+  type ToBigNumberValue,
+} from './toBigNumber'
 
 function divDecimals(value: ?ToBigNumberValue, decimals?: number = 18): BigNumber {
   const base: BigNumber = toBigNumber(10)

--- a/src/utils/numbers/formatBalance.js
+++ b/src/utils/numbers/formatBalance.js
@@ -5,7 +5,7 @@ import {
   toBigNumber,
 } from '.'
 
-import type { ToBigNumberValue } from './toBigNumber'
+import { type ToBigNumberValue } from './toBigNumber'
 
 function formatBalance(value: ?ToBigNumberValue, dp?: number = 2, rm?: number): string {
   if (isZero(value)) {

--- a/src/utils/numbers/fromGweiToWei.js
+++ b/src/utils/numbers/fromGweiToWei.js
@@ -3,9 +3,9 @@
 // $FlowFixMe
 import BigNumber from 'bignumber.js'
 
-import toBigNumber from './toBigNumber'
-
-import type { ToBigNumberValue } from './toBigNumber'
+import toBigNumber, {
+  type ToBigNumberValue,
+} from './toBigNumber'
 
 const UNIT_GWEI = '1000000000'
 

--- a/src/utils/numbers/fromWeiToGWei.js
+++ b/src/utils/numbers/fromWeiToGWei.js
@@ -3,9 +3,9 @@
 // $FlowFixMe
 import BigNumber from 'bignumber.js'
 
-import toBigNumber from './toBigNumber'
-
-import type { ToBigNumberValue } from './toBigNumber'
+import toBigNumber, {
+  type ToBigNumberValue,
+} from './toBigNumber'
 
 const UNIT_GWEI = '1000000000'
 

--- a/src/workers/settings/worker.js
+++ b/src/workers/settings/worker.js
@@ -16,11 +16,10 @@ import {
 import {
   validationPasswordForm,
   changePaymentPasswordPending,
+  type SettingsAction,
 } from 'store/modules/settings'
 
 import * as wallets from 'store/modules/wallets'
-
-import type { SettingsAction } from 'store/modules/settings'
 
 type SettingsWorkerMessage = {|
   +data: SettingsAction,

--- a/src/workers/settings/wrapper.js
+++ b/src/workers/settings/wrapper.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { SettingsAction } from 'store/modules/settings'
+import { type SettingsAction } from 'store/modules/settings'
 
 // eslint-disable-next-line import/default
 import SettingsWorker from './worker.js'

--- a/src/workers/wallets/worker.js
+++ b/src/workers/wallets/worker.js
@@ -17,17 +17,19 @@ import {
   deriveKeyFromPassword,
 } from 'utils/encryption'
 
+/* eslint-disable import/no-duplicates */
 import * as upgrade from 'store/modules/upgrade'
 import * as wallets from 'store/modules/wallets'
 import * as walletsCreate from 'store/modules/walletsCreate'
 import * as walletsImport from 'store/modules/walletsImport'
 import * as walletsBackup from 'store/modules/walletsBackup'
 
-import type { UpgradeAction } from 'store/modules/upgrade'
-import type { WalletsAction } from 'store/modules/wallets'
-import type { WalletsCreateAction } from 'store/modules/walletsCreate'
-import type { WalletsImportAction } from 'store/modules/walletsImport'
-import type { WalletsBackupAction } from 'store/modules/walletsBackup'
+import { type UpgradeAction } from 'store/modules/upgrade'
+import { type WalletsAction } from 'store/modules/wallets'
+import { type WalletsCreateAction } from 'store/modules/walletsCreate'
+import { type WalletsImportAction } from 'store/modules/walletsImport'
+import { type WalletsBackupAction } from 'store/modules/walletsBackup'
+/* eslint-enable import/no-duplicates */
 
 export type WalletsAnyAction =
   UpgradeAction |

--- a/src/workers/wallets/wrapper.js
+++ b/src/workers/wallets/wrapper.js
@@ -11,13 +11,11 @@ import * as walletsCreate from 'store/modules/walletsCreate'
 import * as walletsImport from 'store/modules/walletsImport'
 import * as walletsBackup from 'store/modules/walletsBackup'
 
-import type {
-  WalletsAnyAction,
-  WalletsWorkerInstance,
-} from './worker'
-
 // eslint-disable-next-line import/default
-import WalletsWorker from './worker.js'
+import WalletsWorker, {
+  type WalletsAnyAction,
+  type WalletsWorkerInstance,
+} from './worker.js'
 
 type ImportWalletData = {|
   +data: string,


### PR DESCRIPTION
There is a problem with flowtype, when we are using
```
import type { foo, foo1 } from 'something'
```
`foo` and `foo1` - will be `any` in inspector

And it works good, when types are imported as:
 ```
import { type foo, type foo1 } from 'something'
```

More information about this is here:
https://github.com/flowtype/flow-for-vscode/issues/23
