### PR TITLE
Color fix for hover state of anchors

### DIFF
--- a/src/components/base/JLink/JLink.js
+++ b/src/components/base/JLink/JLink.js
@@ -39,6 +39,7 @@ export function JLink(initialProps: JLinkProps) {
   ])
 
   const className = classnames(
+    jLinkStyle.core,
     theme && jLinkStyle[theme],
     initialClassName,
   )

--- a/src/components/base/JLink/JLink.m.scss
+++ b/src/components/base/JLink/JLink.m.scss
@@ -1,5 +1,8 @@
-@import "styles/colors";
 @import "styles/mixins";
+
+.core {
+  text-decoration: none;
+}
 
 .text-white {
   // FIXME: inherit font from parent

--- a/src/styles/core.scss
+++ b/src/styles/core.scss
@@ -25,15 +25,6 @@ body,
   color: $dusk;
 }
 
-a {
-  text-decoration: none;
-  color: $blue;
-
-  &:hover {
-    color: $blue-two;
-  }
-}
-
 li {
   list-style: none;
 }


### PR DESCRIPTION
Global styles for anchor (`<a>`) were moved to `JLink` styles