### PR TITLE
Exclude network items from persist container

### DIFF
--- a/flow-typed/redux/networks.js
+++ b/flow-typed/redux/networks.js
@@ -26,10 +26,10 @@ declare type Networks = {
 }
 
 declare type NetworksPersist = {|
-  +items: Networks,
   +currentNetworkId: NetworkId,
 |}
 
 declare type NetworksState = {|
+  +items: Networks,
   +persist: NetworksPersist,
 |}

--- a/src/store/modules/networks.js
+++ b/src/store/modules/networks.js
@@ -136,27 +136,27 @@ type NetworksAction =
   ExtractReturn<typeof removeCustomNetwork>
 
 const initialState: NetworksState = {
-  persist: {
-    items: {
-      '3': {
-        id: '3',
-        title: 'Ropsten Test Network',
-        blockExplorerUISubdomain: 'ropsten',
-        rpcaddr: 'ropsten.jnode.network',
-        rpcport: 443,
-        ssl: true,
-        isCustom: false,
-      },
-      '1': {
-        id: '1',
-        blockExplorerUISubdomain: '',
-        title: 'Main Ethereum Network',
-        rpcaddr: 'main.jnode.network',
-        rpcport: 443,
-        ssl: true,
-        isCustom: false,
-      },
+  items: {
+    '3': {
+      id: '3',
+      title: 'Ropsten Test Network',
+      blockExplorerUISubdomain: 'ropsten',
+      rpcaddr: 'ropsten.jnode.network',
+      rpcport: 443,
+      ssl: true,
+      isCustom: false,
     },
+    '1': {
+      id: '1',
+      blockExplorerUISubdomain: '',
+      title: 'Main Ethereum Network',
+      rpcaddr: 'main.jnode.network',
+      rpcport: 443,
+      ssl: true,
+      isCustom: false,
+    },
+  },
+  persist: {
     currentNetworkId: '1',
   },
 }

--- a/src/store/selectors/networks.js
+++ b/src/store/selectors/networks.js
@@ -1,23 +1,21 @@
-// @flow
+// @flow strict
 
-import {
-  ActiveNetworkNotFoundError,
-} from 'errors'
+import { ActiveNetworkNotFoundError } from 'errors'
 
 export function selectNetworks(state: AppState): NetworksState {
   return state.networks
+}
+
+export function selectNetworksItems(state: AppState): Networks {
+  const networks: NetworksState = selectNetworks(state)
+
+  return networks.items
 }
 
 export function selectNetworksPersist(state: AppState): NetworksPersist {
   const networks: NetworksState = selectNetworks(state)
 
   return networks.persist
-}
-
-export function selectNetworksItems(state: AppState): Networks {
-  const networksPersist: NetworksPersist = selectNetworksPersist(state)
-
-  return networksPersist.items
 }
 
 export function selectCurrentNetworkId(state: AppState): NetworkId {
@@ -39,10 +37,10 @@ export function selectCurrentNetworkIdOrThrow(state: AppState): NetworkId {
 export function selectCurrentNetwork(state: AppState): ?Network {
   const {
     items,
-    currentNetworkId,
-  }: NetworksPersist = selectNetworksPersist(state)
+    persist,
+  }: NetworksState = selectNetworks(state)
 
-  return items[currentNetworkId]
+  return items[persist.currentNetworkId]
 }
 
 export function selectCurrentNetworkOrThrow(state: AppState): Network {


### PR DESCRIPTION
Simplest fix of networks.
After jsearch migration this code will be outdated.