### PR TITLE
Unit tests and linting in CI/CD [DEVOPS-408]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,30 @@
-builder()
+builder(
+        jUnitReportsPath: 'junit-reports',
+        coverageReportsPath: 'coverage-reports',
+        buildTasks: [
+                [
+                        name: 'Linters',
+                        type: 'lint',
+                        method: 'inside',
+                        buildStage: 'build',
+                        command: [
+                                // 'npm run lint:css', // TODO: enable CSS linting
+                                'npm run lint:js',
+                        ],
+                ],
+                [
+                        name: 'Tests',
+                        type: 'test',
+                        method: 'inside',
+                        buildStage: 'build',
+                        jUnitPath: '/usr/src/app/reports/unit-tests',
+                        coveragePath: '/usr/src/app/reports/coverage',
+                        environment: [
+                                NODE_ENV: 'production',
+                        ],
+                        command: [
+                                'npm run test:unit',
+                        ],
+                ],
+        ],
+)

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
       statements: 0,
     },
   },
-  coverageDirectory: '<rootDir>/reports/unit-tests/coverage',
+  coverageDirectory: '<rootDir>/reports/coverage',
   coverageReporters: [
     'lcov',
   ],


### PR DESCRIPTION
https://jibrelnetwork.atlassian.net/browse/DEVOPS-408

We have some problems:
- Jest can't execute tests
- `xml` report generated by Jest has no valid information
- coverage report doesn't contain `xml` in Junit format
- linters don't generate Junit reports, I think we should add these modules:
  - https://github.com/jcgertig/eslint-junit
  - https://www.npmjs.com/package/stylelint-junit-formatter

Please, fix these issues and add them into this branch/PR. You can find build logs here:
- https://jenkins.jnode.network/job/jibrelnetwork/job/jwallet-web/job/feature%252Fcicd-tests/
- https://jenkins.jnode.network/blue/organizations/jenkins/jibrelnetwork%2Fjwallet-web/detail/feature%2Fcicd-tests/5/pipeline